### PR TITLE
[ASSIGNMENT] 6차 과제 구현 (Access Token 블랙리스트)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 test {

--- a/src/main/java/org/sopt/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/sopt/domain/auth/controller/AuthController.java
@@ -16,6 +16,7 @@ import org.sopt.global.jwt.CookieUtil;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -72,7 +73,7 @@ public class AuthController {
     )
     @PostMapping("/reissue")
     public ResponseEntity<SuccessResponse<Void>> reissue(
-            @CookieValue(name = "refreshToken") String refreshToken
+            @CookieValue(name = "refreshToken", required = false) String refreshToken
     ) {
         TokenResponse tokens = authService.reissue(refreshToken);
 
@@ -90,12 +91,19 @@ public class AuthController {
     )
     @PostMapping("/logout")
     public ResponseEntity<SuccessResponse<Void>> logout(
-            @CookieValue(name = "refreshToken") String refreshToken
+            @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authHeader,
+            @CookieValue(name = "refreshToken", required = false) String refreshToken
     ) {
-        authService.logout(refreshToken);
+        String accessToken = extractToken(authHeader);
+        authService.logout(accessToken, refreshToken);
 
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, CookieUtil.deleteRefreshToken().toString())
                 .body(SuccessResponse.of(AuthSuccessCode.LOGOUT_SUCCESS));
+    }
+
+    public String extractToken(String bearer) {
+        if (bearer == null || !bearer.startsWith("Bearer ")) return null;
+        return bearer.substring(7);
     }
 }

--- a/src/main/java/org/sopt/domain/auth/service/AuthService.java
+++ b/src/main/java/org/sopt/domain/auth/service/AuthService.java
@@ -17,12 +17,15 @@ import org.sopt.domain.auth.dto.response.TokenResponse;
 import org.sopt.domain.user.entity.User;
 import org.sopt.domain.user.dto.response.UserResponse;
 import org.sopt.domain.user.repository.UserRepository;
+import org.sopt.global.jwt.service.TokenBlacklistService;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -33,6 +36,8 @@ public class AuthService {
     private final JwtProvider jwtProvider;
     private final KakaoOAuthClient kakaoOAuthClient;
     private final PasswordEncoder passwordEncoder;
+    private final TokenBlacklistService tokenBlacklistService;
+    private final RedisTemplate<String, String> redisTemplate;
 
     @Value("${security.jwt.refresh-token-expires-in-seconds:1209600}")
     private long refreshTokenExpiresInSeconds;
@@ -69,6 +74,8 @@ public class AuthService {
         }
 
         TokenResponse tokens = issueTokens(user);
+
+        redisTemplate.opsForValue().set("TEST_KEY", "HELLO", 60, TimeUnit.SECONDS);
 
         return new LoginResult(
                 tokens.accessToken(),
@@ -146,8 +153,14 @@ public class AuthService {
 
 
     @Transactional
-    public void logout(String refreshTokenValue) {
+    public void logout(String accessTokenValue, String refreshTokenValue) {
         refreshTokenRepository.findByToken(refreshTokenValue)
                 .ifPresent(refreshTokenRepository::delete);
+
+        long remaining = jwtProvider.getRemainingExpiration(accessTokenValue);
+
+        if (remaining > 0) {
+            tokenBlacklistService.addToBlacklist(accessTokenValue, remaining);
+        }
     }
 }

--- a/src/main/java/org/sopt/global/config/RedisConfig.java
+++ b/src/main/java/org/sopt/global/config/RedisConfig.java
@@ -1,0 +1,35 @@
+package org.sopt.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(LettuceConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+}

--- a/src/main/java/org/sopt/global/jwt/JwtAuthFilter.java
+++ b/src/main/java/org/sopt/global/jwt/JwtAuthFilter.java
@@ -4,7 +4,9 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.sopt.domain.auth.code.AuthErrorCode;
 import org.sopt.global.exception.CustomException;
+import org.sopt.global.jwt.service.TokenBlacklistService;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -22,13 +24,16 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     private static final String BEARER_PREFIX = "Bearer ";
     private final JwtProvider jwtProvider;
     private final HandlerExceptionResolver resolver;
+    private final TokenBlacklistService tokenBlacklistService;
 
     public JwtAuthFilter(
             JwtProvider jwtProvider,
-            @Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver
+            @Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver,
+            TokenBlacklistService tokenBlacklistService
     ) {
         this.jwtProvider = jwtProvider;
         this.resolver = resolver;
+        this.tokenBlacklistService = tokenBlacklistService;
     }
 
     @Override
@@ -45,6 +50,10 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         String token = header.substring(BEARER_PREFIX.length()).trim();
 
         try {
+            if (tokenBlacklistService.isBlacklisted(token)) {
+                throw new CustomException(AuthErrorCode.INVALID_ACCESS_TOKEN);
+            }
+
             Long userId = jwtProvider.verifyAndGetMemberId(token);
 
             UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(

--- a/src/main/java/org/sopt/global/jwt/JwtProvider.java
+++ b/src/main/java/org/sopt/global/jwt/JwtProvider.java
@@ -72,4 +72,24 @@ public class JwtProvider {
             throw new CustomException(AuthErrorCode.INVALID_ACCESS_TOKEN_SUBJECT);
         }
     }
+
+    public long getRemainingExpiration(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+
+            Date expiration = claims.getExpiration();
+            long now = System.currentTimeMillis();
+
+            return expiration.getTime() - now;
+
+        } catch (ExpiredJwtException e) {
+            return 0;
+        } catch (JwtException e) {
+            throw new CustomException(AuthErrorCode.INVALID_ACCESS_TOKEN);
+        }
+    }
 }

--- a/src/main/java/org/sopt/global/jwt/service/TokenBlacklistService.java
+++ b/src/main/java/org/sopt/global/jwt/service/TokenBlacklistService.java
@@ -1,0 +1,31 @@
+package org.sopt.global.jwt.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class TokenBlacklistService {
+
+    private static final String BLACKLIST_PREFIX = "BL:";
+    private static final String LOGOUT_VALUE = "logout";
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void addToBlacklist(String accessToken, long remainingMillis) {
+        if (remainingMillis <= 0) return;
+        redisTemplate.opsForValue().set(
+                BLACKLIST_PREFIX + accessToken,
+                LOGOUT_VALUE,
+                remainingMillis,
+                TimeUnit.MILLISECONDS
+        );
+    }
+
+    public boolean isBlacklisted(String accessToken) {
+        return redisTemplate.hasKey(BLACKLIST_PREFIX + accessToken);
+    }
+}


### PR DESCRIPTION
# 🔥*Pull requests*


## 👷 **과제 구현**

### 필수과제

<br>

### 선택과제
- [x] 로그아웃 API를 구현해주세요. 로그아웃 시 DB에서 해당 유저의 Refresh Token을 삭제하고, 현재 Access Token을 블랙리스트에 추가해서 만료 전에도 사용할 수 없도록 해주세요. Access Token이 만료됐을 때 클라이언트가 어떻게 401을 감지해서 로그인 페이지로 이동시킬지 흐름도 함께 작성해주세요.

<br>

### **구현한 내용에 대해서 설명해주세요**

로그아웃 시 Access Token을 무효화하기 위해 Redis 기반 블랙리스트 기능을 구현하였습니다.

기존 JWT는 stateless 특성상 서버에서 직접 무효화할 수 없기 때문에,
로그아웃된 Access Token을 Redis에 저장하고, 남은 만료 시간(TTL)을 설정하여 자동으로 제거되도록 처리했습니다.

이후 모든 요청에 대해 JWT 필터에서 블랙리스트 여부를 검사하여,
로그아웃된 토큰으로의 재요청을 차단하도록 구현했습니다.

- Redis (localhost:6379) 사용
- Key: "BL:{accessToken}"
- TTL: Access Token의 남은 만료 시간

postman 및 redis-cli로 redis에 블랙리스트로 추가할 access token이 정상적으로 추가되고, 블랙리스트에 추가된 access token으로 접근 시, 설정한 에러 코드가 정상적으로 반환되었음을 확인하였습니다.

<br>


### **구현하며 고민했던 내용을 적어주세요 (사소한 것도 좋아요)**

블랙리스트에 포함된 access token으로 접근 시, 일단은 기존 AuthErrorCode에서 유효하지 않은 Access Token으로 접근 시 사용하는 에러코드 인 `INVALID_ACCESS_TOKEN`를 그대로 사용했는데, 블랙리스트에 들어간 Access Token임을 명시적으로 알려줄 수 있는 에러코드로 따로 처리를 하는게 맞는지...고민이 되었습니다.

<br>

---
### **키워드 과제 정리내용**


<br>

---

## 🚨 참고 사항

close #20